### PR TITLE
Remove unecessary components

### DIFF
--- a/App/VSTS/QuickActions.tsx
+++ b/App/VSTS/QuickActions.tsx
@@ -2,10 +2,9 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import { ItemHyperlink } from  './ItemHyperlink';
-import { FollowButton } from './FollowButton';
+// import { FollowButton } from './FollowButton';
 import { ReplyAllButton } from './ReplyAllButton';
 import { CopyButton } from './CopyButton';
-import { RestButton } from './RestButton';
 import { IWorkItem } from '../statesEZ';
 import { connect } from 'react-redux';
 import * as ReactDOM from 'react-dom/server';
@@ -66,10 +65,8 @@ export class QuickActions extends React.Component<IQuickActionProps, {isReady: b
         <h1 className='ms-font-1x ms-fontWeight-light ms-fontColor-black'>Work item successfully created!</h1>
         <ItemHyperlink workItemHyperlink={htmlString}/>
         <h1 className='ms-font-1x ms-fontWeight-light ms-fontColor-black'>Quick Actions:</h1>
-        <FollowButton />
         <ReplyAllButton workItemHyperlink={htmlString}/>
         <CopyButton workItemHyperlink={htmlString}/>
-        <RestButton />
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dropdown": "^1.0.4",
     "react-redux": "^4.1.2",
     "react-router": "^2.4.1",
-    "react-select": "^1.0.0",
+    "react-select": "^0.9.1",
     "react-tap-event-plugin": "^0.2.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",


### PR DESCRIPTION
To get rid of components from the Quick Actions component that are no longer needed. Rest Button was for testing. Follow Button is removed until the REST APIs from VSTS are made available.
