### PR TITLE
Reorganize redux files

### DIFF
--- a/App/Redux/GlobalReducer.ts
+++ b/App/Redux/GlobalReducer.ts
@@ -3,6 +3,7 @@
 import { Reducer, combineReducers } from 'redux';
 import { updateUserProfileReducer, updateSettingsAndListsReducer } from './LoginReducer';
 import { updateControlStateReducer} from './FlowReducer';
+import { workItemReducer } from './WorkItemReducer';
 
 /**
  * combined reducer for entire application
@@ -10,4 +11,6 @@ import { updateControlStateReducer} from './FlowReducer';
  */
 export const completeAddInReducer: Reducer = combineReducers({ controlState : updateControlStateReducer,
     currentSettings : updateSettingsAndListsReducer,
-    userProfile: updateUserProfileReducer});
+    userProfile: updateUserProfileReducer,
+    workItem: workItemReducer,
+});

--- a/App/Redux/WorkItemActions.ts
+++ b/App/Redux/WorkItemActions.ts
@@ -1,3 +1,4 @@
+import { PageVisibility } from './FlowActions';
 /**
  * enum for Actions
  * @type {enum}

--- a/App/Redux/WorkItemActions.ts
+++ b/App/Redux/WorkItemActions.ts
@@ -1,0 +1,204 @@
+/**
+ * enum for Actions
+ * @type {enum}
+ */
+export enum ACTION {STAGE,
+                    GEAR,
+                    WORKITEMTYPE,
+                    NEWTITLE,
+                    NEWDESCRIPTION,
+                    ADDASATTACHMENT,
+                    FOLLOWSTATE,
+                    SAVE,
+                    POSTCREATION}
+
+/**
+ * enum for the stages in the Follow Process
+ * @type {enum}
+ */
+export enum FollowTypes {Followed,
+                         Unfollowed}
+
+/**
+ * enum for Stage of the edit process of the work item
+ * @type {enum}
+ */
+export enum Stage {New,
+                   Draft,
+                   Saved}
+
+// export enum PageVisibility {Settings, CreateItem, InProcess, QuickActions} // remove upon merge since Miranda's part will make this enum
+
+ /**
+  * Represents the Stage Action
+  * @interface IStageAction
+  */
+export interface IStageAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * Flag to signal the stage the user is on: New if no edits are make, Draft if edits were made, Saved if the user created the work item
+     * @type {Stage}
+     */
+  stage: Stage;
+}
+ /**
+  * Represents the Gear Action
+  * @interface IGearAction
+  */
+export interface IGearAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * The page that is visible to the user/rendered
+     * @type {PageVisibility}
+     */
+  pageVisibility: PageVisibility;
+}
+ /**
+  * Represents the WorkItemType Action
+  * @interface IWorkItemTypeAction
+  */
+export interface IWorkItemTypeAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * the workItemType selected
+     * @type {string}
+     */
+  workItemType: string;
+}
+ /**
+  * Represents the Title Action
+  * @interface ITitleAction
+  */
+export interface ITitleAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * the title of the work item
+     * @type {string}
+     */
+  title: string;
+}
+ /**
+  * Represents the Description Action
+  * @interface IDescriptionAction
+  */
+export interface IDescriptionAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * the description of the work item
+     * @type {string}
+     */
+  description: string;
+}
+ /**
+  * Represents the AddAsAttachment Action
+  * @interface IAddAsAttachmentAction
+  */
+export interface IAddAsAttachmentAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * represents whether to attach the email to the work item or not
+     * @type {boolean}
+     */
+  addAsAttachment: boolean;
+}
+ /**
+  * Represents the Save Action
+  * @interface ISaveAction
+  */
+export interface ISaveAction {
+    /**
+     * the type of the action
+     * @type {ACTION}
+     */
+  type: ACTION;
+    /**
+     * The page that is visible to the user/rendered
+     * @type {PageVisibility}
+     */
+  pageVisibility: PageVisibility;
+    /**
+     * The link to the newly created VSTS work item
+     * @type {string}
+     */
+  VSTShtmlLink: string;
+    /**
+     * The id the newly created VSTS work item
+     * @type {string}
+     */
+  id: string;
+}
+  /**
+   * Handles update of the stage
+   * @param {Stage} stage
+   */
+export function updateStage (stage: Stage): IStageAction {
+  return {type: ACTION.STAGE, stage};
+}
+  /**
+   * Handles update of the pageVisibility
+   * @param {PageVisibility} pageVisibility
+   */
+export function updateGearVisiblility (pageVisibility: PageVisibility): IGearAction {
+  return {type: ACTION.GEAR, pageVisibility};
+}
+  /**
+   * Handles update of the workItemType
+   * @param {string} workItemType
+   */
+export function updateWorkItemType (workItemType: string): IWorkItemTypeAction {
+   return {type: ACTION.WORKITEMTYPE, workItemType};
+ }
+  /**
+   * Handles update of the title
+   * @param {string} title
+   */
+export function updateTitle (title: string): ITitleAction {
+   return {type: ACTION.NEWTITLE, title};
+ }
+  /**
+   * Handles update of the description
+   * @param {string} description
+   */
+export function updateDescription (description: string): IDescriptionAction {
+   return {type: ACTION.NEWDESCRIPTION, description};
+ }
+  /**
+   * Handles update of addAsAttachment
+   * @param {boolean} addAsAttachment
+   */
+export function updateAddAsAttachment (addAsAttachment: boolean): IAddAsAttachmentAction {
+   return {addAsAttachment: !addAsAttachment, type: ACTION.ADDASATTACHMENT};
+ }
+  /**
+   * Handles update of the pageVisibility, VSTShtmlLink, and id
+   * @param {PageVisibility} pageVisibility
+   * @param {string} VSTShtmlLink
+   * @param {string} id
+   */
+export function updateSave (pageVisibility: PageVisibility, VSTShtmlLink: string, id: string): ISaveAction {
+  return {type: ACTION.SAVE, pageVisibility, VSTShtmlLink, id};
+}

--- a/App/Redux/WorkItemActions.ts
+++ b/App/Redux/WorkItemActions.ts
@@ -137,11 +137,6 @@ export interface ISaveAction {
      */
   type: ACTION;
     /**
-     * The page that is visible to the user/rendered
-     * @type {PageVisibility}
-     */
-  pageVisibility: PageVisibility;
-    /**
      * The link to the newly created VSTS work item
      * @type {string}
      */
@@ -158,13 +153,6 @@ export interface ISaveAction {
    */
 export function updateStage (stage: Stage): IStageAction {
   return {type: ACTION.STAGE, stage};
-}
-  /**
-   * Handles update of the pageVisibility
-   * @param {PageVisibility} pageVisibility
-   */
-export function updateGearVisiblility (pageVisibility: PageVisibility): IGearAction {
-  return {type: ACTION.GEAR, pageVisibility};
 }
   /**
    * Handles update of the workItemType
@@ -200,6 +188,6 @@ export function updateAddAsAttachment (addAsAttachment: boolean): IAddAsAttachme
    * @param {string} VSTShtmlLink
    * @param {string} id
    */
-export function updateSave (pageVisibility: PageVisibility, VSTShtmlLink: string, id: string): ISaveAction {
-  return {type: ACTION.SAVE, pageVisibility, VSTShtmlLink, id};
+export function updateSave (VSTShtmlLink: string, id: string): ISaveAction {
+  return {type: ACTION.SAVE, VSTShtmlLink, id};
 }

--- a/App/Redux/WorkItemReducer.ts
+++ b/App/Redux/WorkItemReducer.ts
@@ -1,0 +1,89 @@
+// import { Reducer, combineReducers } from 'redux';
+import { ACTION, FollowTypes, Stage } from './WorkItemActions';
+ /**
+  * Represents the part of the state for the new WorkItem
+  * @interface IWorkItem
+  */
+export interface IWorkItem {
+    /**
+     * Flag to signal the stage the user is on: New if no edits are make, Draft if edits were made, Saved if the user created the work item
+     * @type {Stage}
+     */
+  stage: Stage;
+    /**
+     * the type of the work item
+     * @type {string}
+     */
+  workItemType: string;
+    /**
+     * the title of the work item
+     * @type {string}
+     */
+  title: string;
+    /**
+     * the description of the work item
+     * @type {string}
+     */
+  description: string;
+    /**
+     * whether to attach the email to the newly created work item
+     * @type {boolean}
+     */
+  addAsAttachment: boolean;
+    /**
+     * where the use is in the process of Following a work item
+     * @type {FollowStateTypes}
+     */
+  followState: FollowTypes;
+    /**
+     * the htmlLink of the newly created VSTS work item
+     * @type {string}
+     */
+  VSTShtmlLink: string;
+    /**
+     * the id of the newly created VSTS work item
+     * @type {string}
+     */
+  id: string;
+}
+/**
+ * The initial state of the workItem state 
+ * @const
+ */
+export const initalState: IWorkItem = {
+  VSTShtmlLink: '',
+  addAsAttachment: true,
+  description: 'For more details, please refer to the attached email thread. ',
+  followState: FollowTypes.Unfollowed,
+  id: '',
+  stage: Stage.New,
+  title : '',
+  workItemType: 'Bug',
+};
+
+  /**
+   * Handles changing the value of the fields with each action
+   * @param {IWorkItem} state
+   * @param {any} action
+   */
+export function workItemReducer(state: IWorkItem = initalState, action: any): IWorkItem {
+  switch (action.type) {
+    case ACTION.STAGE:
+      return Object.assign( {}, state, {stage : action.stage});
+    case ACTION.WORKITEMTYPE:
+      return Object.assign( {}, state, {workItemType : action.workItemType});
+    case ACTION.NEWTITLE:
+      return Object.assign( {}, state, {title : action.title});
+    case ACTION.NEWDESCRIPTION:
+      return Object.assign( {}, state, {description : action.description});
+    case ACTION.ADDASATTACHMENT:
+      return Object.assign( {}, state, {addAsAttachment : action.addAsAttachment});
+    default:
+      return state;
+ }
+}
+/**
+ * The reducer for the workItem state
+ * @const
+ */
+// export const testreducer: Reducer = combineReducers({ workItem : workItemReducer});

--- a/App/Redux/WorkItemReducer.ts
+++ b/App/Redux/WorkItemReducer.ts
@@ -51,13 +51,13 @@ export interface IWorkItem {
  * @const
  */
 export const initalState: IWorkItem = {
-  VSTShtmlLink: '',
+  VSTShtmlLink: 'https://www.visualstudio.com/products/what-is-visual-studio-online-vs?WT.srch=1&WT.mc_ID=SEM_xXsQTNj1',
   addAsAttachment: true,
   description: 'For more details, please refer to the attached email thread. ',
   followState: FollowTypes.Unfollowed,
-  id: '',
+  id: '<work item id>',
   stage: Stage.New,
-  title : '',
+  title: '',
   workItemType: 'Bug',
 };
 

--- a/App/VSTS/Classification.tsx
+++ b/App/VSTS/Classification.tsx
@@ -1,22 +1,29 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { AccountDropdown } from './SettingsComponents/AccountDropdown';
+import { AreaDropdown } from './SettingsComponents/AreaDropdown';
+import { ProjectDropdown } from './SettingsComponents/ProjectDropdown';
 
 /**
  * Renders the Acccount, Project, and Area components
  * @class {Classification}
  */
 export class Classification extends React.Component<{}, {}> {
-
-/**
- * Renders the Account, Project, and Area components
- */
-public render(): React.ReactElement<Provider> {
-
-  return ( <div>
-  <div className='ms-font-1x ms-fontWeight-semibold ms-fontColor-black'> CLASSIFICATION </div>
-  Mirandas Components here :)
-   </div>);
-
+  /**
+   * Renders the Account, Project, and Area components
+   */
+  public render(): React.ReactElement<Provider> {
+    return (
+      <div>
+        <div className='ms-font-1x ms-fontWeight-semibold ms-fontColor-black'> CLASSIFICATION
+          <div>
+            Account: <AccountDropdown />
+            Project: <ProjectDropdown />
+            Area: <AreaDropdown />
+          </div>
+        </div>
+    </div>
+    );
   }
 }
 

--- a/App/VSTS/CreateWorkItem.tsx
+++ b/App/VSTS/CreateWorkItem.tsx
@@ -14,9 +14,9 @@ import { Gear } from './Gear';
 
 export class CreateWorkItem extends React.Component<{}, {}> {
 
-  public isReady: boolean; // set to false
+  // public isReady: boolean; // set to false
 
-  private Initialize(): void {
+  /*private Initialize(): void {
     this.isReady = true;
     this.forceUpdate(); // re-renders page
   }
@@ -26,17 +26,16 @@ export class CreateWorkItem extends React.Component<{}, {}> {
     this.isReady = false;
     this.Initialize = this.Initialize.bind(this);
     Office.initialize = this.Initialize;
-  }
+  }*/
 
 /**
  * Renders the div that contains all the components of the Create page
  */
 public render(): React.ReactElement<{}> {
-
   console.log('got to create pg');
-  if (this.isReady === false) {
+ /* if (this.isReady === false) {
     return (<div>loading!!</div>);
-  }
+  }*/
 
   return (<div>
   <Gear />

--- a/App/VSTS/Description.tsx
+++ b/App/VSTS/Description.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Provider, connect } from 'react-redux';
-import { updateAddAsAttachment, updateDescription, Stage } from '../Reducers/ActionsET';
+import { updateAddAsAttachment, updateDescription, Stage } from '../Redux/WorkItemActions';
 
  /**
   * Represents the Description Properties
@@ -32,10 +32,9 @@ export interface IDescriptionProps {
  */
 function mapStateToProps (state: any): IDescriptionProps  {
   return {addAsAttachment: state.workItem.addAsAttachment, description: state.workItem.description, stage: state.workItem.stage} ;
-   }
+}
 
 @connect (mapStateToProps)
-
 export class Description extends React.Component<IDescriptionProps, {}> {
 
 /**

--- a/App/VSTS/Gear.tsx
+++ b/App/VSTS/Gear.tsx
@@ -1,48 +1,50 @@
 import * as React from 'react';
 import { Provider, connect } from 'react-redux';
-// import { changeGearVisiblility, PageVisibilityEnum } from '../Reducers/ActionsET';
+import { updatePageAction, PageVisibility } from '../Redux/FlowActions';
 
 /**
  * Represents the Gear Properties
  * @interface IGearProps
  */
 export interface IGearProps {
-/**
- * dispatch to map dispatch to props
- * @type {any}
- */
-    dispatch?: any;
+  /**
+   * dispatch to map dispatch to props
+   * @type {any}
+   */
+  dispatch?: any;
 }
 
-@connect ()
+@connect()
 /**
  * Renders the Gear Icon and the button underneath
  * @class { Gear }
  */
 export class Gear extends React.Component<IGearProps, {}> {
-/**
- * Dispatches the action to change the pageVisibility value in the store
- * @ returns {void}
- */
-public handlegearClick(): void {
-  //  this.props.dispatch(changeGearVisiblility(PageVisibilityEnum.Settings));
-    console.log('dispatch action here to change visibility enum');
+  /**
+   * Renders the Gear Icon and the button underneath
+   */
+  public render(): React.ReactElement<Provider> {
+    let gear: any = {
+      align: 'right',
+    };
+
+    return (
+      <div>
+        <div className='ms-font-1x ms-fontWeight-light ms-fontColor-black'> Create Work Item
+          <button className='ms-Button' style = {gear} id='gear' onClick = {this.handleGearClick}>
+          <span className='ms-Icon ms-Icon--gear'> </span>
+          </button>
+        </div>
+      </div>
+    );
   }
-/**
- * Renders the Gear Icon and the button underneath
- */
-public render(): React.ReactElement<Provider> {
 
-let gear: any = {
-  align: 'right',
-};
-
-
-return ( <div>
-    <div className='ms-font-1x ms-fontWeight-light ms-fontColor-black'> Create Work Item
-    <button className='ms-Button' style = {gear} id='gear' onClick = {this.handlegearClick}>
-    <span className='ms-Icon ms-Icon--gear'> </span>
-    </button>
-    </div> </div>);
+  /**
+   * Dispatches the action to change the pageVisibility value in the store
+   * @ returns {void}
+   */
+  private handleGearClick: () => void = () => {
+    console.log('dispatch action here to change visibility enum');
+    this.props.dispatch(updatePageAction(PageVisibility.Settings));
   }
 }

--- a/App/VSTS/QuickActions.tsx
+++ b/App/VSTS/QuickActions.tsx
@@ -5,7 +5,7 @@ import { ItemHyperlink } from  './ItemHyperlink';
 // import { FollowButton } from './FollowButton';
 import { ReplyAllButton } from './ReplyAllButton';
 import { CopyButton } from './CopyButton';
-import { IWorkItem } from '../statesEZ';
+import { IWorkItem } from '../Redux/WorkItemReducer';
 import { connect } from 'react-redux';
 import * as ReactDOM from 'react-dom/server';
 
@@ -27,7 +27,7 @@ interface IQuickActionProps {
  */
 function mapStateToProps(state: any): IQuickActionProps {
   return {
-    workItem: state.workItemState,
+    workItem: state.workItem,
   };
 }
 

--- a/App/VSTS/Save.tsx
+++ b/App/VSTS/Save.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { Provider, connect } from 'react-redux';
 // import { changeSave, StageEnum } from '../Reducers/ActionsET';
 import { Rest } from '../RestHelpers/rest';
-import { updateStage, Stage } from '../Reducers/ActionsET';
+import { updateStage, Stage } from '../Redux/WorkItemActions';
 import { IWorkItem } from '../Reducers/ReducersET';
+import { updatePageAction, PageVisibility } from '../Redux/FlowActions';
+
  /**
   * Represents the Save Properties
   * @interface ISaveProps
@@ -26,67 +28,67 @@ export interface ISaveProps {
  * @class { Save }
  */
 function mapStateToProps (state: any): ISaveProps  {
-      return { workItem: state.workItem };
+  return { workItem: state.workItem };
 }
 
 @connect (mapStateToProps)
-
 export class Save extends React.Component<ISaveProps, {}> {
-/**
- * States whether to disable the save button or not
- * @type {boolean}
- */
-   public isDisabled: boolean = false;
-/**
- * Dispatches the action to change the Stage and make the REST call to create the work item
- * @returns {void}
- */
-
-   public handleSave(): void {
+  /**
+   * States whether to disable the save button or not
+   * @type {boolean}
+   */
+  public isDisabled: boolean = false;
+  /**
+   * Dispatches the action to change the Stage and make the REST call to create the work item
+   * @returns {void}
+   */
+  public handleSave(): void {
       let options: any = { account: 'o365exchange', project: 'Outlook Services', teamName: 'Ecosystem - Ext VSTS'};
       let token: any = Office.context.mailbox.getCallbackTokenAsync;
       let OutlookitemID: any = Office.context.mailbox.item.itemId;
       let ewsURL: any = Office.context.mailbox.ewsUrl;
       this.props.dispatch(updateStage(Stage.Saved));
-  /*    Rest.createWorkItem('t-emtenc@microsoft.com', options, token, OutlookitemID, ewsURL,
+      /*    Rest.createWorkItem('t-emtenc@microsoft.com', options, token, OutlookitemID, ewsURL,
       this.props.workItem.workItemType, this.props.workItem.title, this.props.workItem.description, (output) => console.log(output));*/
       Rest.getCurrentIteration('t-emtenc@microsoft.com', options, this.props.workItem.workItemType, this.props.workItem.title, this.props.workItem.description, (output) => console.log(output));
-      
-  }
+      this.props.dispatch(updatePageAction(PageVisibility.QuickActions));
+    }
 
-/**
- * Renders the Save button and disables it on click
- */
-public render(): React.ReactElement<Provider> {
-
-/**
- * Style for the live save button
- */
-let save: any = {
+  /**
+   * Renders the Save button and disables it on click
+   */
+  public render(): React.ReactElement<Provider> {
+    /**
+     * Style for the live save button
+     */
+    let save: any = {
       align: 'center',
       background: '#80ccff',
       height: '35px',
       width: '250px',
-};
+    };
 
-/**
- * Style for the disabled save button
- */
-let disabled: any = {
+    /**
+     * Style for the disabled save button
+     */
+    let disabled: any = {
       align: 'center',
       background: '#d9d9d9',
       height: '35px',
       width: '250px',
-};
-/**
- * Decides which style to use for the stage button based on the Stage
- */
-let currentStyle: any = this.props.workItem.stage === Stage.Saved ? disabled : save;
+    };
 
-return (<div>
-    <br/>
-    <button className = 'ms-Button' style= {currentStyle} disabled = {this.props.workItem.stage === Stage.Saved}
-      onClick = {this.handleSave.bind(this)} > Create Work Item </button>
-    </div>);
+    /**
+     * Decides which style to use for the stage button based on the Stage
+     */
+    let currentStyle: any = this.props.workItem.stage === Stage.Saved ? disabled : save;
+    return (
+      <div>
+        <br/>
+        <button className = 'ms-Button' style= {currentStyle} disabled = {this.props.workItem.stage === Stage.Saved}
+          onClick = {this.handleSave.bind(this)} > Create Work Item
+        </button>
+      </div>
+    );
   }
- }
+}

--- a/App/VSTS/Title.tsx
+++ b/App/VSTS/Title.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Provider, connect } from 'react-redux';
-import { updateTitle, updateStage, Stage } from '../Reducers/ActionsET';
+import { updateTitle, updateStage, Stage } from '../Redux/WorkItemActions';
 
  /**
   * Represents the Title Properties

--- a/App/VSTS/VSTS.tsx
+++ b/App/VSTS/VSTS.tsx
@@ -1,14 +1,16 @@
 /// <reference path="../../office.d.ts" />
 import * as React from 'react';
-import {Provider, connect } from 'react-redux';
-import {LogInPage } from './LoginComponents/LogInPage';
-import {Settings} from './SettingsComponents/Settings';
-import {Loading } from './SimpleComponents/Loading';
-import {Connecting } from './SimpleComponents/Connecting';
-import {Auth } from './authMM';
+import { Provider, connect } from 'react-redux';
+import { LogInPage } from './LoginComponents/LogInPage';
+import { Settings} from './SettingsComponents/Settings';
+import { Loading } from './SimpleComponents/Loading';
+import { Connecting } from './SimpleComponents/Connecting';
+import { Auth } from './authMM';
 import { updateUserProfileAction} from '../Redux/LoginActions';
-import {PageVisibility, AuthState, updateAuthAction, IErrorStateAction, updatePageAction} from '../Redux/FlowActions';
-import { UserProfile} from '../RestHelpers/rest';
+import { PageVisibility, AuthState, updateAuthAction, IErrorStateAction, updatePageAction } from '../Redux/FlowActions';
+import { UserProfile } from '../RestHelpers/rest';
+import { CreateWorkItem } from './CreateWorkItem';
+import { QuickActions } from './QuickActions';
 
 interface IRefreshCallback { (): void; }
 interface IUserProfileCallback { (profile: UserProfile): void; }
@@ -96,12 +98,12 @@ export class VSTS extends React.Component<IVSTSProps, any> {
         {
             switch (this.props.pageState) {
               case PageVisibility.CreateItem:
-                return (<div>Create Item...</div>);
+                return (<CreateWorkItem />);
               case PageVisibility.QuickActions:
-                return (<div>Quick Actions...</div>);
+                return (<QuickActions />);
               case PageVisibility.Settings:
               default:
-              return (<Settings />);
+                return (<Settings />);
             }
         }
       default:

--- a/App/VSTS/WorkItemDropdown.tsx
+++ b/App/VSTS/WorkItemDropdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Provider, connect } from 'react-redux';
-import { updateWorkItemType } from '../Reducers/ActionsET';
+import { updateWorkItemType } from '../Redux/WorkItemActions';
 
 require ('react-select/dist/react-select.css');
 let Select: any = require('react-select');


### PR DESCRIPTION
In this commit: 
- Migrated content of files ActionsET and ReducersET to Redux/WorkItemActions and Redux/WorkItemReducer
- Renamed all routes in files related to ActionsET and ReducersET to new files
- Added page logic for CreateWorkItem -> Settings and CreateWorkItem -> Quick Actions
- Added Settings Dropdowns to CreateWorkItem page
